### PR TITLE
change README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 <p>
   <b>Target Audience</b><br>
-  Tourists, hikers, someone who are looking for a place to walk with their dog, or anyone in Vancouver interested in visiting a park or seeing a view.
+  Tourists, hikers and someone who are looking for a place to walk with their dog.
 </p>
 
 <p>
@@ -64,7 +64,7 @@
 
 <p>
   <b>Application Utility:</b><br>
-  Viewfinder reduce the required time in finding a desirable park. The efforts of personally visiting parks and collecting their own data is saved. Our application will allow users to only visit the best parks immediately. Our application will also keep users safe by providing information on which parks are safe to visit which is especially important to users that plan on taking children.
+  Viewfinder reduces the required time in finding a desirable park. The efforts of personally visiting parks and collecting their own data are saved. Our application will allow users to only visit the best parks immediately. Our application will also keep users safe by providing information on park safety which is especially important to users with a child.
 </p>
 
 <p>


### PR DESCRIPTION
1. Remove redundancy. "Tourists" includes "anyone in Vancouver interested in visiting a park or seeing a view". Simply combine them into one sentence.
2. Grammar. "ViewFinder reduce" changes to "ViewFinder reduces", "visiting parks and collecting their data is saved" changes to "visiting parks and collecting their data are saved".
3. "Our application will also keep users safe by providing information on which parks are safe to visit which is especially important to users that plan on taking children." This sentence contains three clauses. This is too complex and breaking the long sentence into easy to understand sentence. "Our application will also keep users safe by providing information on park safety which is especially important to users with a child" This one only contains one clause.
